### PR TITLE
set timezone in web and database images

### DIFF
--- a/dev/docker/database/Dockerfile
+++ b/dev/docker/database/Dockerfile
@@ -1,5 +1,8 @@
 # start with a standard mariadb image
 FROM mariadb
 
+# use delphi's timezome
+RUN ln -s -f /usr/share/zoneinfo/America/New_York /etc/localtime
+
 # specify a development-only password for the database user "root"
 ENV MYSQL_ROOT_PASSWORD pass

--- a/dev/docker/web/Dockerfile
+++ b/dev/docker/web/Dockerfile
@@ -8,5 +8,9 @@ RUN mv "$PHP_INI_DIR/php.ini-production" "$PHP_INI_DIR/php.ini"
 RUN docker-php-ext-install mysqli
 RUN docker-php-ext-enable mysqli
 
+# use delphi's timezome
+RUN ln -s -f /usr/share/zoneinfo/America/New_York /etc/localtime
+RUN sed -i $PHP_INI_DIR/php.ini -e 's/^;date.timezone =$/date.timezone = "America\/New_York"/'
+
 # deploy development secrets (see `operations/deploy.json`)
 COPY repos/delphi/operations/dev/docker/web/assets/secrets.php /var/www/html/


### PR DESCRIPTION
- brings the development environment slightly closer to the production 
environment
- makes debugging a little more natural