### PR TITLE
deploy non-midas secrets

### DIFF
--- a/deploy.json
+++ b/deploy.json
@@ -23,23 +23,13 @@
       "add-header-comment": true
     },
 
-    "// python secrets for things running on midas",
+    "// non-midas python secrets",
     {
       "type": "copy",
       "src": "src/secrets.py",
       "dst": "../delphi/operations/secrets.py",
       "replace-keywords": [
         "../secrets.json"
-      ],
-      "add-header-comment": true
-    },
-    "// python secrets for deploying repos outside of midas",
-    {
-      "type": "copy",
-      "src": "src/secrets.py",
-      "dst": "../delphi/operations/secrets_campus.py",
-      "replace-keywords": [
-        "../secrets_campus.json"
       ],
       "add-header-comment": true
     },


### PR DESCRIPTION
- this way deploying `operations` doesn't clobber the bootstrap secrets