### PR TITLE
screenshot of the covidcast map

### DIFF
--- a/dev/docker/python/assets/requirements.txt
+++ b/dev/docker/python/assets/requirements.txt
@@ -1,4 +1,5 @@
 beautifulsoup4
+docker
 dropbox
 epiweeks
 google-api-python-client

--- a/src/screenshots/README.md
+++ b/src/screenshots/README.md
@@ -1,0 +1,8 @@
+# screenshots
+
+This subpackage contains code and resources for making automatic, headless
+screenshots of various Delphi web properties, including
+[COVIDcast](https://covidcast.cmu.edu/).
+
+Drivers for each screenshot task are organized into subpackages within this
+directory.

--- a/src/screenshots/covidcast/map_preview.py
+++ b/src/screenshots/covidcast/map_preview.py
@@ -1,0 +1,127 @@
+"""Takes a screenshot of the COVIDcast map.
+
+Extraneous UI is hidden so that the map is presentable in standalone form. The
+screenshot is intended to be suitable for use in social media previews and
+custom dashboards.
+"""
+
+# standard library
+import argparse
+import time
+import urllib.parse
+
+# third party
+from selenium.webdriver.support.wait import WebDriverWait
+from selenium import webdriver
+
+# first party
+from delphi.operations.screenshots.utils import Utils
+
+
+class MapPreview:
+
+  # URL of the COVIDcast map with predetermined signals
+  URL = 'https://covidcast.cmu.edu/?' + urllib.parse.urlencode({
+    'sensor': 'doctor-visits-smoothed_adj_cli',
+    'level': 'county',
+    'date': '20200918',
+    'signalType': 'value',
+    'encoding': 'color',
+    'mode': 'overview',
+    'region': '42003',
+  })
+
+  # width and height in pixels of the final screenshot
+  SCREENSHOT_SIZE = (1800, 900)
+
+  # width and height in pixels of the virtual screen needed to capture a
+  # screenshot of the desired size (e.g. to allow room for surrounding UI
+  # elements, window borders, etc)
+  SCREEN_SIZE = (SCREENSHOT_SIZE[0], SCREENSHOT_SIZE[1] + 311)
+
+  # location of the center of Allegheny county in pixels relative to the
+  # top-left corner of the map
+  ALLEGHENY_COUNTY_LOCATION = (1077, 372)
+
+  def take_screenshot(driver, path, time_impl=time, webdriver_impl=webdriver):
+    """Take a screenshot of the COVIDcast map.
+
+    Parameters
+    ----------
+    driver : selenium.webdriver.remote.webdriver
+        A webdriver instance, which is already connected to a selenium server.
+    path : str
+        The absolute path of the file where the screenshot is rendered.
+    """
+
+    print(f'navigating to {MapPreview.URL}')
+    driver.get(MapPreview.URL)
+    if 'COVIDcast' not in driver.title:
+      raise Exception(f'unexpected title ({driver.title})')
+
+    def is_loading(document):
+      spinners = document.find_elements_by_class_name('loading-bg')
+      return len(spinners) > 0
+
+    print('waiting for map to load')
+    WebDriverWait(driver, 10).until_not(is_loading)
+
+    root = driver.find_elements_by_css_selector('main.root')[0]
+
+    print('hiding extra ui')
+    options = root.find_elements_by_class_name('options-container')[0]
+    search = root.find_elements_by_class_name('search-container')[0]
+    compare = root.find_elements_by_class_name('panel-bottom-wrapper')[0]
+    driver.execute_script('arguments[0].style.display="none"', options)
+    driver.execute_script('arguments[0].style.display="none"', search)
+    driver.execute_script('arguments[0].style.display="none"', compare)
+
+    print('resetting map view')
+    controls = root.find_elements_by_class_name('map-controls-container')[0]
+    home_button = controls.find_elements_by_class_name('pg-button')[2]
+    home_button.click()
+    # allow time for the animation to complete
+    time_impl.sleep(5)
+
+    print('hovering allegheny county')
+    webdriver_impl.ActionChains(driver).move_to_element_with_offset(
+        root, *MapPreview.ALLEGHENY_COUNTY_LOCATION).perform()
+    # allow time for the county info popup to appear
+    time_impl.sleep(1)
+
+    print(f'rendering screenshot at {path}')
+    root.screenshot(path)
+
+  def get_argument_parser():
+    """Define command line arguments and usage.
+
+    Returns
+    -------
+    argparse.ArgumentParser
+        A parser for command line arguments.
+    """
+
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        '--path',
+        type=str,
+        required=True,
+        help='absolute path of generated screenshot (e.g. /path/name.png)')
+    return parser
+
+  def main(path, utils_impl=Utils):
+    """Capture a screenshot of COVIDcast.
+
+    Parameters
+    ----------
+    path : str
+        The absolute path of the file where the screenshot is rendered.
+    """
+
+    with utils_impl.run_screenshot_stack(MapPreview.SCREEN_SIZE) as driver:
+      MapPreview.take_screenshot(driver, path)
+
+
+if __name__ == '__main__':
+  args = MapPreview.get_argument_parser().parse_args()
+  MapPreview.main(args.path)

--- a/src/screenshots/covidcast/map_preview.py
+++ b/src/screenshots/covidcast/map_preview.py
@@ -109,19 +109,30 @@ class MapPreview:
     print('waiting for map to load')
     WebDriverWait(driver, 10).until_not(is_loading)
 
-    root = driver.find_elements_by_css_selector('main.root')[0]
+    def find_element(func, query, index):
+      elements = func(query)
+      if index >= len(elements):
+        raise MapPreviewException(f'unable to locate element {query} #{index}')
+      return elements[index]
+
+    root = find_element(driver.find_elements_by_css_selector, 'main.root', 0)
 
     print('hiding extra ui')
-    options = root.find_elements_by_class_name('options-container')[0]
-    search = root.find_elements_by_class_name('search-container')[0]
-    compare = root.find_elements_by_class_name('panel-bottom-wrapper')[0]
+    options = find_element(
+        root.find_elements_by_class_name, 'options-container', 0)
+    search = find_element(
+        root.find_elements_by_class_name, 'search-container', 0)
+    compare = find_element(
+        root.find_elements_by_class_name, 'panel-bottom-wrapper', 0)
     driver.execute_script('arguments[0].style.display="none"', options)
     driver.execute_script('arguments[0].style.display="none"', search)
     driver.execute_script('arguments[0].style.display="none"', compare)
 
     print('resetting map view')
-    controls = root.find_elements_by_class_name('map-controls-container')[0]
-    home_button = controls.find_elements_by_class_name('pg-button')[2]
+    controls = find_element(
+        root.find_elements_by_class_name, 'map-controls-container', 0)
+    home_button = find_element(
+        controls.find_elements_by_class_name, 'pg-button', 2)
     home_button.click()
     # allow time for the animation to complete
     time_impl.sleep(5)
@@ -191,18 +202,18 @@ class MapPreview:
     parser.add_argument(
         '--hover_x',
         type=int,
-        default=0,
+        default=1077,
         help=(
           'horizontal location to mouse hover, '
-          'in pixels relative to top-left (default 0)'
+          'in pixels relative to top-left (default 1077)'
         ))
     parser.add_argument(
         '--hover_y',
         type=int,
-        default=0,
+        default=372,
         help=(
           'vertical location to mouse hover, '
-          'in pixels relative to top-left (default 0)'
+          'in pixels relative to top-left (default 372)'
         ))
     return parser
 

--- a/src/screenshots/docker/Dockerfile
+++ b/src/screenshots/docker/Dockerfile
@@ -1,0 +1,2 @@
+# start with the standard selenium chome base image
+FROM selenium/standalone-chrome

--- a/src/screenshots/docker/README.md
+++ b/src/screenshots/docker/README.md
@@ -1,0 +1,18 @@
+# `delphi_screenshot`
+
+This image is based on a standard [selenium](https://www.selenium.dev/) chrome
+image. Currently there is nothing else added on top of that base image. In
+other words, `delphi_screenshot` is essentially just an alias for that base
+image. Although this is a bit redundant, it allows us to easily add additional
+things to `delphi_screenshot` in the future without having to update image
+names in dependent code.
+
+This image is used by the [../covidcast](COVIDcast screenshot utility), which
+produces specially tailored screenshots of the COVIDcast website.
+
+The recommend build command for this image, from automation's `driver`
+directory is:
+
+```
+docker build -t delphi_screenshot delphi/operations/screenshots/docker
+```

--- a/src/screenshots/utils.py
+++ b/src/screenshots/utils.py
@@ -1,0 +1,271 @@
+"""Contains functionally required by most screenshot drivers.
+
+Functionallity includes:
+- docker commands for starting the `delphi_screenshot` server
+- initialization of the selenium webdriver
+- graceful setup and teardown
+"""
+
+# standard library
+from contextlib import contextmanager
+import datetime
+
+# first party
+import time
+
+# third party
+import docker
+from selenium import webdriver
+from selenium.webdriver.common.desired_capabilities import DesiredCapabilities
+
+
+class TimeUtils:
+
+  def wait_for_condition(predicate, timeout, time_impl=time):
+    """
+    Block until a condition is met or until a timeout has elapsed, whichever
+    happens first.
+
+    Parameters
+    ----------
+    predicate : function
+        A function which takes no arguments and returns a bool indicating
+        whether the condition has been met.
+    timeout : datetime.timedelta
+        The maximum amount of time to wait before returning. Note that the
+        condition is checked once per second, so timeouts are effectively
+        lower-bounded by one second.
+    """
+
+    is_condition_met = predicate()
+    end_time = time_impl.time() + timeout.total_seconds()
+    while not is_condition_met and time_impl.time() < end_time:
+      time_impl.sleep(1)
+      is_condition_met = predicate()
+    return is_condition_met
+
+
+class DockerUtils:
+
+  # the name (or tag, in docker terms) of the screenshot image
+  IMAGE_NAME = 'delphi_screenshot'
+
+  # a relative path to the build context and Dockerfile
+  BUILD_CONTEXT_PATH = 'delphi/operations/screenshots/docker'
+
+  # the port on which the upstream selenium image listens
+  SELENIUM_HOST_PORT = '4444/tcp'
+
+  # the magic log string which indicates that the selenium server is ready
+  SELENIUM_READY_MESSAGE = b'Selenium Server is up and running'
+
+  def build_image(docker_client):
+    """Build the screenshot image.
+
+    Parameters
+    ----------
+    docker_client : docker.DockerClient
+        A client for communicating with a Docker server.
+
+    Returns
+    -------
+    docker.models.images.Image
+        A handle to the image that was built.
+    """
+
+    print(f'building {DockerUtils.IMAGE_NAME}')
+    return docker_client.images.build(
+        path=DockerUtils.BUILD_CONTEXT_PATH,
+        tag=DockerUtils.IMAGE_NAME,
+        forcerm=True)
+
+  @contextmanager
+  def run_container(docker_client, screen_size):
+    """Run the screenshot container.
+
+    A direct call yields a single container instance. However, this function is
+    meant to be called indirectly as a context manager, in which case the
+    container is provided through a `with` statement.
+
+    To prevent blocking, the container is started in the background, in
+    detached mode. It must be explicitly stopped, otherwise it would run
+    forever. The context manager stops the container when the `with` block
+    exits.
+
+    To avoid accumulation of stopped containers, the `auto_remove` option is
+    enabled, which causes the docker engine to delete the container upon exit.
+
+    Parameters
+    ----------
+    docker_client : docker.DockerClient
+        A client for communicating with a Docker server.
+    screen_size : (int, int)
+        The width and height in pixels of the virtual screen.
+
+    Yields
+    -------
+    docker.models.containers.Container
+        A handle to the container that was started.
+    """
+
+    print(f'running {DockerUtils.IMAGE_NAME}')
+    container = docker_client.containers.run(
+        DockerUtils.IMAGE_NAME,
+        # delete the container after it exists
+        auto_remove=True,
+        # start the container in the background
+        detach=True,
+        # pass the given screen dimensions
+        environment={
+          'SCREEN_WIDTH': f'{screen_size[0]}',
+          'SCREEN_HEIGHT': f'{screen_size[1]}',
+        },
+        # forward an ephemeral port on localhost to the contained server
+        ports={
+          DockerUtils.SELENIUM_HOST_PORT: ('127.0.0.1', None),
+        },
+        # the selenium chrome container requires much more than the default
+        # amount of shared memory; see
+        # https://github.com/SeleniumHQ/docker-selenium/blob/trunk/README.md#quick-start
+        shm_size='2g')
+
+    try:
+      yield container
+    finally:
+      container.stop()
+      print('container stopped')
+
+  def is_server_ready(container):
+    """Return whether the selenium server is ready to accept connections.
+
+    Parameters
+    ----------
+    container : docker.models.containers.Container
+        A container running a selenium server.
+
+    Returns
+    -------
+    bool
+        Whether the selenium server is ready to accept connections.
+    """
+
+    return DockerUtils.SELENIUM_READY_MESSAGE in container.logs(tail=1)
+
+  def wait_for_server(container, time_utils_impl=TimeUtils):
+    """Wait for the selenium server to become ready.
+
+    Parameters
+    ----------
+    container : docker.models.containers.Container
+        A container running a selenium server.
+
+    Raises
+    ------
+    Exception
+        If the server isn't ready after 10 seconds.
+    """
+
+    print('waiting for server to initialize')
+    predicate = lambda: DockerUtils.is_server_ready(container)
+    timeout = datetime.timedelta(seconds=10)
+    if not time_utils_impl.wait_for_condition(predicate, timeout):
+      raise Exception('timeout waiting for server to initialize')
+
+  def get_host_port(docker_client, container_id):
+    """Get the TCP port number which is forwarded to the container.
+
+    Parameters
+    ----------
+    docker_client : docker.DockerClient
+        A client for communicating with a Docker server.
+    container_id : str
+        The ID of the container to inspect.
+
+    Returns
+    -------
+    int
+        The TCP port number which is forwarded to the container.
+    """
+
+    container = docker_client.containers.get(container_id)
+    return container.ports[DockerUtils.SELENIUM_HOST_PORT][0]['HostPort']
+
+
+class SeleniumUtils:
+
+  @contextmanager
+  def get_driver(port, webdriver_impl=webdriver):
+    """Create a webdriver for a Chrome instance in a local selenium container.
+
+    A direct call yields a single driver instance. However, this function is
+    meant to be called indirectly as a context manager, in which case the
+    driver is provided through a `with` statement.
+
+    It's best practice to close the driver when finished, which is done
+    automatically in this case by using a context manager.
+
+    Parameters
+    ----------
+    port : int
+        The local TCP port on which the selenium server is listening.
+
+    Yields
+    -------
+    selenium.webdriver.remote.webdriver
+        A remote webdriver instance connected to a local selenium container.
+    """
+
+    print('connecting to chrome')
+    driver = webdriver_impl.Remote(
+        command_executor=f'http://127.0.0.1:{port}/wd/hub',
+        desired_capabilities=DesiredCapabilities.CHROME)
+
+    try:
+      yield driver
+    finally:
+      driver.close()
+      print('driver closed')
+
+
+class Utils:
+
+  @contextmanager
+  def run_screenshot_stack(
+      screen_size,
+      docker_impl=docker,
+      docker_utils_impl=DockerUtils,
+      selenium_utils_impl=SeleniumUtils):
+    """Start the screenshot stack and return a live webdriver.
+
+    A direct call yields a single driver instance. However, this function is
+    meant to be called indirectly as a context manager, in which case the
+    driver is provided through a `with` statement.
+
+    All resource initialization and cleanup is handled though context managers.
+
+    Parameters
+    ----------
+    screen_size : (int, int)
+        The width and height in pixels of the virtual screen.
+
+    Yields
+    -------
+    selenium.webdriver.remote.webdriver
+        A remote webdriver instance connected to a local selenium container.
+    """
+
+    docker_client = docker_impl.from_env()
+    docker_utils_impl.build_image(docker_client)
+
+    with docker_utils_impl.run_container(
+        docker_client, screen_size) as container:
+
+      docker_utils_impl.wait_for_server(container)
+      # get the port only after the server is ready
+      port = docker_utils_impl.get_host_port(docker_client, container.id)
+
+      with selenium_utils_impl.get_driver(port) as driver:
+
+        # make the virtual browser window fullscreen in the virtual display
+        driver.fullscreen_window()
+        yield driver

--- a/tests/screenshots/covidcast/test_map_preview.py
+++ b/tests/screenshots/covidcast/test_map_preview.py
@@ -1,0 +1,64 @@
+"""Unit tests for map_preview.py."""
+
+# standard library
+import argparse
+import unittest
+from unittest.mock import MagicMock, patch, sentinel
+
+# py3tester coverage target
+__test_target__ = 'delphi.operations.screenshots.covidcast.map_preview'
+
+
+class MapPreviewTests(unittest.TestCase):
+
+  def test_take_screenshot(self):
+    """Run through the screenshot flow."""
+
+    mock_map = MagicMock()
+    mock_driver = MagicMock()
+    mock_driver.title = 'COVIDcast'
+    mock_driver.find_elements_by_css_selector.return_value = [mock_map]
+
+    MapPreview.take_screenshot(
+        mock_driver,
+        sentinel.path,
+        time_impl=MagicMock(),
+        webdriver_impl=MagicMock())
+
+    # there are many calls, but this is the last and most important
+    mock_map.screenshot.assert_called_once_with(sentinel.path)
+
+  def test_take_screenshot_checks_page_title(self):
+    """Don't take a screenshot when the page title is unexpected."""
+
+    mock_driver = MagicMock()
+    mock_driver.title = 'foo'
+
+    with self.assertRaises(Exception):
+      MapPreview.take_screenshot(
+          mock_driver,
+          sentinel.path,
+          time_impl=MagicMock(),
+          webdriver_impl=MagicMock())
+
+  def test_get_argument_parser(self):
+    """Return an ArgumentParser."""
+
+    result = MapPreview.get_argument_parser()
+    self.assertIsInstance(result, argparse.ArgumentParser)
+
+  def test_main(self):
+    """Launch the main entry point."""
+
+    mock_context = MagicMock()
+    mock_context.__enter__.return_value = sentinel.driver
+    mock_utils = MagicMock()
+    mock_utils.run_screenshot_stack.return_value = mock_context
+
+    with patch.object(MapPreview, 'take_screenshot') as mock_take_screenshot:
+      MapPreview.main(sentinel.path, utils_impl=mock_utils)
+      mock_take_screenshot.assert_called_once_with(
+          sentinel.driver, sentinel.path)
+
+    mock_utils.run_screenshot_stack.assert_called_once_with(
+        MapPreview.SCREEN_SIZE)

--- a/tests/screenshots/covidcast/test_map_preview.py
+++ b/tests/screenshots/covidcast/test_map_preview.py
@@ -36,10 +36,11 @@ class MapPreviewTests(unittest.TestCase):
       MapPreview.get_most_recent_date(
           None, None, None, None, epidata_impl=mock_epidata)
 
-  def test_take_screenshot(self):
+  def test_take_screenshot_saves_screenshot(self):
     """Run through the screenshot flow."""
 
     mock_map = MagicMock()
+    mock_map.find_elements_by_class_name.return_value = [mock_map] * 10
     mock_driver = MagicMock()
     mock_driver.title = 'COVIDcast'
     mock_driver.find_elements_by_css_selector.return_value = [mock_map]
@@ -66,7 +67,22 @@ class MapPreviewTests(unittest.TestCase):
       MapPreview.take_screenshot(
           mock_driver,
           MagicMock(),
-          sentinel.date,
+          None,
+          time_impl=MagicMock(),
+          webdriver_impl=MagicMock())
+
+  def test_take_screenshot_shows_failure_reason(self):
+    """Re-wrap screenshot exceptions with a hint of what caused the failure."""
+
+    mock_driver = MagicMock()
+    mock_driver.title = 'COVIDcast'
+    mock_driver.find_elements_by_css_selector.return_value = []
+
+    with self.assertRaises(MapPreviewException):
+      MapPreview.take_screenshot(
+          mock_driver,
+          MagicMock(),
+          None,
           time_impl=MagicMock(),
           webdriver_impl=MagicMock())
 

--- a/tests/screenshots/test_utils.py
+++ b/tests/screenshots/test_utils.py
@@ -1,0 +1,176 @@
+"""Unit tests for utils.py."""
+
+# standard library
+import datetime
+import unittest
+from unittest.mock import MagicMock, sentinel
+
+# py3tester coverage target
+__test_target__ = 'delphi.operations.screenshots.utils'
+
+
+class TimeUtilsTests(unittest.TestCase):
+
+  def test_wait_for_condition_immediately_true(self):
+    """Don't wait for a condition that's already met."""
+
+    predicate = lambda: True
+    timeout = datetime.timedelta(minutes=1)
+
+    result = TimeUtils.wait_for_condition(
+        predicate, timeout, time_impl=MagicMock())
+
+    self.assertTrue(result)
+
+  def test_wait_for_condition_before_timeout(self):
+    """Wait for a condition without timing out."""
+
+    predicate = MagicMock(side_effect=[False, True])
+    timeout = datetime.timedelta(minutes=1)
+    mock_time = MagicMock()
+    mock_time.time.return_value = 123
+
+    result = TimeUtils.wait_for_condition(
+        predicate, timeout, time_impl=mock_time)
+
+    self.assertTrue(result)
+
+  def test_wait_for_condition_until_timeout(self):
+    """Wait for a condition, exceeding the time limit."""
+
+    predicate = lambda: False
+    timeout = datetime.timedelta(minutes=1)
+    mock_time = MagicMock()
+    mock_time.time.side_effect = range(100)
+
+    result = TimeUtils.wait_for_condition(
+        predicate, timeout, time_impl=mock_time)
+
+    self.assertFalse(result)
+
+
+class DockerUtilsTests(unittest.TestCase):
+
+  def test_build_image(self):
+    """Build the screenshot image."""
+
+    mock_docker_client = MagicMock()
+    mock_docker_client.images.build.return_value = sentinel.image
+
+    result = DockerUtils.build_image(mock_docker_client)
+
+    self.assertEqual(result, sentinel.image)
+
+  def test_run_container(self):
+    """Start and stop a container."""
+
+    screen_size = (123, 456)
+    mock_container = MagicMock()
+    mock_docker_client = MagicMock()
+    mock_docker_client.containers.run.return_value = mock_container
+
+    with DockerUtils.run_container(
+        mock_docker_client, screen_size) as container:
+
+      mock_docker_client.containers.run.assert_called_once()
+      args, kwargs = mock_docker_client.containers.run.call_args
+      env = kwargs['environment']
+      self.assertEqual(env['SCREEN_WIDTH'], '123')
+      self.assertEqual(env['SCREEN_HEIGHT'], '456')
+
+      self.assertEqual(container, mock_container)
+      mock_container.stop.assert_not_called()
+
+    mock_container.stop.assert_called_once()
+
+  def test_is_server_ready_not_ready(self):
+    """Indicate that the server is not ready."""
+
+    mock_container = MagicMock()
+    mock_container.logs.return_value = b'foo'
+
+    result = DockerUtils.is_server_ready(mock_container)
+
+    self.assertFalse(result)
+
+  def test_is_server_ready_ready(self):
+    """Indicate that the server is ready."""
+
+    mock_container = MagicMock()
+    logs = b'foo' + DockerUtils.SELENIUM_READY_MESSAGE + b'bar'
+    mock_container.logs.return_value = logs
+
+    result = DockerUtils.is_server_ready(mock_container)
+
+    self.assertTrue(result)
+
+  def test_wait_for_server_without_timeout(self):
+    """Block until the server is ready."""
+
+    mock_time_utils = MagicMock()
+    mock_time_utils.wait_for_condition.return_value = True
+
+    DockerUtils.wait_for_server(MagicMock(), time_utils_impl=mock_time_utils)
+
+    mock_time_utils.wait_for_condition.assert_called_once()
+
+  def test_wait_for_server_with_timeout(self):
+    """Raise when server is not ready by the timeout."""
+
+    mock_time_utils = MagicMock()
+    mock_time_utils.wait_for_condition.return_value = False
+
+    with self.assertRaises(Exception):
+      DockerUtils.wait_for_server(MagicMock(), time_utils_impl=mock_time_utils)
+
+    mock_time_utils.wait_for_condition.assert_called_once()
+
+  def test_get_host_port(self):
+    """Inspect a running container to get the listening port."""
+
+    mock_container = MagicMock()
+    mock_container.ports = {
+      DockerUtils.SELENIUM_HOST_PORT: [{'HostPort': sentinel.port}],
+    }
+    mock_docker_client = MagicMock()
+    mock_docker_client.containers.get.return_value = mock_container
+
+    result = DockerUtils.get_host_port(
+        mock_docker_client, sentinel.container_id)
+
+    mock_docker_client.containers.get.assert_called_once_with(
+        sentinel.container_id)
+    self.assertEqual(result, sentinel.port)
+
+
+class TestSeleniumUtils(unittest.TestCase):
+
+  def test_get_driver(self):
+    """Connect and disconnect from a selenium server."""
+
+    mock_driver = MagicMock()
+    mock_webdriver = MagicMock()
+    mock_webdriver.Remote.return_value = mock_driver
+
+    with SeleniumUtils.get_driver(
+        sentinel.port, webdriver_impl=mock_webdriver) as driver:
+
+      mock_webdriver.Remote.assert_called_once()
+      self.assertEqual(driver, mock_driver)
+      mock_driver.close.assert_not_called()
+
+    mock_driver.close.assert_called_once()
+
+
+class TestUtils(unittest.TestCase):
+
+  def test_run_screenshot_stack_goes_fullscreen(self):
+    """After bringing up the stack, make the browser fullscreen."""
+
+    with Utils.run_screenshot_stack(
+        sentinel.screen_size,
+        docker_impl=MagicMock(),
+        docker_utils_impl=MagicMock(),
+        selenium_utils_impl=MagicMock()) as driver:
+
+      driver.fullscreen_window.assert_called_once()


### PR DESCRIPTION
Not a high priority feature request, but requested in https://github.com/cmu-delphi/www-covidcast/issues/489 and https://github.com/cmu-delphi/www-covidcast/issues/442.

As we're starting to think about containerization in production, and not just development, this project is a first foray into running a containerized workload in automation. Here's the idea:

- automation periodically runs the python program `map_preview`
- `map_preview` call `utils` to build and run a selenium+chrome container
- `map_preview` takes a screenshot of covidcast, which is rendered virtually in chrome in the container
- `utils` gracefully handles teardown of all the things
- the screenshot is dropped into a location that httpd hosts (e.g. ~/public_html)
- as needed, we update social media / survey previews with the latest preview image

Sample output:
![screenshot](https://user-images.githubusercontent.com/20584512/97496151-88dc4f00-1936-11eb-8039-3f614c5d0855.png)

(The file can be resized like: `convert screenshot.png -filter Lanczos -resize 1024x512 screenshot_small.png`)

---

See commits for more details, but basically I add:

1. a new dockerfile and some readmes
2. the utilities for docker and selenium, which are useful for screenshots in general
3. the map preview screenshot tool, which is specific to the covidcast map

---

```
✔ All 16 tests passed! 98% (105/107) coverage.
```