### PR TITLE
[Database metrics] Add function for easily testing many datasets

### DIFF
--- a/src/database_metrics/monitor.py
+++ b/src/database_metrics/monitor.py
@@ -45,9 +45,9 @@ def measure_database(datasets: list,
     query_funcs = [partial(send_query, params=p) for p in queries]
     meta_func = partial(update_meta, client=client)
     for dataset in datasets:
-        load_func = partial(load_data, client=client, source=dataset[0], file_pattern=datasets[1])
         if not append_data:
             _clear_db(db_container)
+        load_func = partial(load_data, client=client, source=dataset[0], file_pattern=dataset[1])
         output["load"].append(get_metrics(load_func, db_container))
         output["meta"].append(get_metrics(meta_func, db_container))
         for i, query in enumerate(query_funcs):
@@ -66,7 +66,6 @@ def get_metrics(func: Callable, container: Container) -> tuple:
     This polling behavior is also the reason for the use of `else: break` in the for loop instead of
     `while worker_process.is_alive()`, since keeping the same container.stats generator instead of
     calling it each loop lets us capture more data points.
-
 
     Parameters
     ----------

--- a/src/database_metrics/monitor.py
+++ b/src/database_metrics/monitor.py
@@ -1,9 +1,79 @@
 import multiprocessing as mp
 import time
+from functools import partial
 from typing import Callable
 
 from docker.models.containers import Container
-from .db_actions import _get_epidata_db_size
+from docker import DockerClient
+from .db_actions import _get_epidata_db_size, _clear_db
+from .actions import load_data, update_meta, send_query
+
+
+def measure_database(datasets: list,
+                     client: DockerClient,
+                     db_container: Container,
+                     queries: list = [],
+                     append_data: bool=False) -> dict:
+    """
+    Measure performance metrics for a list of functions and datasets.
+
+    For each dataset in `datasets`, measure load time, metadata update time, and optional queries.
+    Datasets are specified by a tuple of (source, file_pattern).
+    e.g. ("usa-facts", "202003*_county*"), which will load all the county level usa-facts data
+    for March 2020.
+
+    Examples
+    ________
+    # Measure metrics for load and metadata of usa-facts and fb-survey independently.
+    measure_database([("fb-survey", "*"), ("usa-facts", "*")],
+                     client,
+                     container)
+
+    # Measure metrics for load, metadata, and a query on March and March+April usa-facts data.
+    query1 = {"source": "covidcast",
+              "data_source": "usa-facts",
+              "signal": "deaths_incidence_num",
+              "time_type": "day",
+              "geo_type": "county",
+              "time_values": "20200301-2020501",
+              "geo_value": "*"}
+    measure_database([("usa-facts", "202003*_county*"), ("usa-facts", "202004*_county*")],
+                     client,
+                     container,
+                     [query1],
+                     append_data=True)
+
+    Parameters
+    ----------
+    datasets: list of tuples
+        List of 2-tuples defined as (source, patterns for files) to be included in each dataset.
+    client: DockerClient
+        DockerClient object to access and execute python images.
+    db_container: Container
+        Docker container object containing the database to measure.
+    queries: list of dictionaries, optional
+        List of query parameters to test query runtimes on.
+    append_data: boolean, optional
+        Boolean for whether to append each dataset onto the previous one (True), or clear the
+        database for each dataset (False). Defaults to False.
+
+    Returns
+    -------
+    Dictionary of metrics. Keys will be the datasets and values will be dicts containing the output
+    of parse_metrics() for loading, metadata updates, and queries.
+    """
+    output = {}
+    query_funcs = [partial(send_query, params=p) for p in queries]
+    meta_func = partial(update_meta, client=client)
+    for dataset in datasets:
+        load_func = partial(load_data, client=client, source=dataset[0], file_pattern=datasets[1])
+        if not append_data:
+            _clear_db(db_container)
+        output[dataset]["load"] = get_metrics(load_func, db_container)
+        output[dataset]["meta"] = get_metrics(meta_func, db_container)
+        for i, query in enumerate(query_funcs):
+            output[dataset][f"query{i}"] = get_metrics(query, db_container)
+    return output
 
 
 def get_metrics(func: Callable, container: Container) -> tuple:

--- a/src/database_metrics/monitor.py
+++ b/src/database_metrics/monitor.py
@@ -13,7 +13,7 @@ def measure_database(datasets: list,
                      client: DockerClient,
                      db_container: Container,
                      queries: list = [],
-                     append_data: bool=False) -> dict:
+                     append_data: bool = False) -> dict:
     """
     Measure performance metrics for a list of functions and datasets.
 
@@ -21,27 +21,6 @@ def measure_database(datasets: list,
     Datasets are specified by a tuple of (source, file_pattern).
     e.g. ("usa-facts", "202003*_county*"), which will load all the county level usa-facts data
     for March 2020.
-
-    Examples
-    ________
-    # Measure metrics for load and metadata of usa-facts and fb-survey independently.
-    measure_database([("fb-survey", "*"), ("usa-facts", "*")],
-                     client,
-                     container)
-
-    # Measure metrics for load, metadata, and a query on March and March+April usa-facts data.
-    query1 = {"source": "covidcast",
-              "data_source": "usa-facts",
-              "signal": "deaths_incidence_num",
-              "time_type": "day",
-              "geo_type": "county",
-              "time_values": "20200301-2020501",
-              "geo_value": "*"}
-    measure_database([("usa-facts", "202003*_county*"), ("usa-facts", "202004*_county*")],
-                     client,
-                     container,
-                     [query1],
-                     append_data=True)
 
     Parameters
     ----------
@@ -52,7 +31,7 @@ def measure_database(datasets: list,
     db_container: Container
         Docker container object containing the database to measure.
     queries: list of dictionaries, optional
-        List of query parameters to test query runtimes on.
+        List of query parameters to test query runtimes on. Defaults to empty list.
     append_data: boolean, optional
         Boolean for whether to append each dataset onto the previous one (True), or clear the
         database for each dataset (False). Defaults to False.
@@ -62,17 +41,17 @@ def measure_database(datasets: list,
     Dictionary of metrics. Keys will be the datasets and values will be dicts containing the output
     of parse_metrics() for loading, metadata updates, and queries.
     """
-    output = {}
+    output = {"load": [], "meta": []}
     query_funcs = [partial(send_query, params=p) for p in queries]
     meta_func = partial(update_meta, client=client)
     for dataset in datasets:
         load_func = partial(load_data, client=client, source=dataset[0], file_pattern=datasets[1])
         if not append_data:
             _clear_db(db_container)
-        output[dataset]["load"] = get_metrics(load_func, db_container)
-        output[dataset]["meta"] = get_metrics(meta_func, db_container)
+        output["load"].append(get_metrics(load_func, db_container))
+        output["meta"].append(get_metrics(meta_func, db_container))
         for i, query in enumerate(query_funcs):
-            output[dataset][f"query{i}"] = get_metrics(query, db_container)
+            output.get(f"query{i}", []).append(get_metrics(query, db_container))
     return output
 
 

--- a/src/database_metrics/monitor.py
+++ b/src/database_metrics/monitor.py
@@ -42,7 +42,7 @@ def measure_database(datasets: list,
     Dictionary of metrics. Keys will be the datasets and values will be dicts containing the output
     of parse_metrics() for loading, metadata updates, and queries.
     """
-    output = {"load": [], "meta": [], "append_datasets": append_datasets}
+    output = {"load": [], "meta": [], "datasets": datasets, "append_datasets": append_datasets}
     query_funcs = [partial(send_query, params=p) for p in queries]
     meta_func = partial(update_meta, client=client)
     for dataset in datasets:

--- a/src/database_metrics/parsers.py
+++ b/src/database_metrics/parsers.py
@@ -40,7 +40,7 @@ def parse_metrics(metrics: tuple) -> dict:
     -------
     Dictionary containing final disk usage, runtime, and list of memory usage during function call.
     """
-    output = {"db_disk_usage_mb": parse_db_size(metrics[0]),
+    output = {"db_disk_usage_mb": parse_db_size(metrics[0].output),
               "runtime": metrics[1],
-              "memory_usage_mb": [i["memory_stats"]["usage"] / 1024 / 1024 for i in metrics[2]]}
+              "memory_usage_mb": max(i["memory_stats"]["usage"] / 1024 / 1024 for i in metrics[2])}
     return output

--- a/src/database_metrics/parsers.py
+++ b/src/database_metrics/parsers.py
@@ -42,5 +42,5 @@ def parse_metrics(metrics: tuple) -> dict:
     """
     output = {"db_disk_usage_mb": parse_db_size(metrics[0].output),
               "runtime": metrics[1],
-              "memory_usage_mb": max(i["memory_stats"]["usage"] / 1024 / 1024 for i in metrics[2])}
+              "max_mem_usage_mb": max(i["memory_stats"]["usage"] / 1024 / 1024 for i in metrics[2])}
     return output

--- a/tests/database_metrics/test_monitor.py
+++ b/tests/database_metrics/test_monitor.py
@@ -25,20 +25,26 @@ class TestMonitor(unittest.TestCase):
             {"table_rows": 1, "db_disk_usage_mb": 2., "runtime": 3, "memory_usage_mb": 4},
             {"table_rows": 5, "db_disk_usage_mb": 6., "runtime": 7, "memory_usage_mb": 8},
             {"table_rows": 9, "db_disk_usage_mb": 10., "runtime": 11, "memory_usage_mb": 12},
+            {"table_rows": 2, "db_disk_usage_mb": 4., "runtime": 6, "memory_usage_mb": 8},
+            {"table_rows": 1, "db_disk_usage_mb": 3., "runtime": 5, "memory_usage_mb": 7},
+            {"table_rows": 3, "db_disk_usage_mb": 6., "runtime": 9, "memory_usage_mb": 12},
         ]
         expected = {
-            "datasets": [("a", "b")],
+            "datasets": [("a", "b"), ("c", "d")],
             "append_datasets": False,
             "load": [
-                {"table_rows": 1, "db_disk_usage_mb": 2., "runtime": 3, "memory_usage_mb": 4}
+                {"table_rows": 1, "db_disk_usage_mb": 2., "runtime": 3, "memory_usage_mb": 4},
+                {"table_rows": 2, "db_disk_usage_mb": 4., "runtime": 6, "memory_usage_mb": 8}
             ],
             "meta": [
-                {"table_rows": 5, "db_disk_usage_mb": 6., "runtime": 7, "memory_usage_mb": 8}
+                {"table_rows": 5, "db_disk_usage_mb": 6., "runtime": 7, "memory_usage_mb": 8},
+                {"table_rows": 1, "db_disk_usage_mb": 3., "runtime": 5, "memory_usage_mb": 7}
             ],
             "query0": [
-                {"table_rows": 9, "db_disk_usage_mb": 10., "runtime": 11, "memory_usage_mb": 12}
+                {"table_rows": 9, "db_disk_usage_mb": 10., "runtime": 11, "memory_usage_mb": 12},
+                {"table_rows": 3, "db_disk_usage_mb": 6., "runtime": 9, "memory_usage_mb": 12}
             ],
         }
-        output = monitor.measure_database([("a", "b")], None, None, ["q1"])
+        output = monitor.measure_database([("a", "b"), ("c", "d")], None, None, ["q1"])
         self.assertDictEqual(output, expected)
-        mock_clear.assert_called_once()
+        self.assertEqual(mock_clear.call_count, 2)

--- a/tests/database_metrics/test_monitor.py
+++ b/tests/database_metrics/test_monitor.py
@@ -1,0 +1,44 @@
+"""Tests for monitor.py"""
+import unittest
+from unittest.mock import patch, MagicMock
+
+from delphi.operations.database_metrics import monitor
+
+# py3tester coverage target
+__test_target__ = 'delphi.operations.database_metrics.monitor'
+
+
+class TestMonitor(unittest.TestCase):
+
+    @patch("delphi.operations.database_metrics.monitor._clear_db")
+    @patch("delphi.operations.database_metrics.monitor.parse_metrics")
+    @patch("delphi.operations.database_metrics.monitor.get_metrics")
+    def test_measure_database(self, mock_metrics, mock_parser, mock_clear):
+        # mock_container = MagicMock()
+        # mock_container.exec_run.return_value = None
+        # mock_docker_client = MagicMock()
+        # mock_docker_client.containers.run.return_value = mock_container
+
+        mock_metrics.return_value = None
+        mock_clear.return_value = None
+        mock_parser.side_effect = [
+            {"table_rows": 1, "db_disk_usage_mb": 2., "runtime": 3, "memory_usage_mb": 4},
+            {"table_rows": 5, "db_disk_usage_mb": 6., "runtime": 7, "memory_usage_mb": 8},
+            {"table_rows": 9, "db_disk_usage_mb": 10., "runtime": 11, "memory_usage_mb": 12},
+        ]
+        expected = {
+            "datasets": [("a", "b")],
+            "append_datasets": False,
+            "load": [
+                {"table_rows": 1, "db_disk_usage_mb": 2., "runtime": 3, "memory_usage_mb": 4}
+            ],
+            "meta": [
+                {"table_rows": 5, "db_disk_usage_mb": 6., "runtime": 7, "memory_usage_mb": 8}
+            ],
+            "query0": [
+                {"table_rows": 9, "db_disk_usage_mb": 10., "runtime": 11, "memory_usage_mb": 12}
+            ],
+        }
+        output = monitor.measure_database([("a", "b")], None, None, ["q1"])
+        self.assertDictEqual(output, expected)
+        mock_clear.assert_called_once()


### PR DESCRIPTION
Currently branched off `add_rows` since it needs some of those functions. Also the code is all prototype and I haven't actually run it yet.

#### Summary of Changes:
- Add a function that lets people easily submit a number of datasets and queries to run and capture metrics for.

The output format could get a bit messy due to the number of options and how far the dicts could get nested. The append_data option also adds a complication, since if it's True you'll want to capture either the order or the preceding datasets, and dicts can't have lists as keys and are unordered. I've implemented a fairly basic format right now with just a dict of lists, which hopefully is easy to extract and plot. I can imagine a number of other implementations that might all work fine though. @krivard any suggestions?

#### Examples
Measure metrics for load and metadata of usa-facts and fb-survey independently.
```
measure_database([("fb-survey", "*"), ("usa-facts", "*")],
                 client,
                 container)
```
Outputs something like 
```
# `<metrics>` is currently a dict
{
  "load": [<metrics>, <metrics>],
  "meta": [<metrics>, <metrics>]
}
```
Example call to measure metrics for load, metadata, and a query on March and March+April usa-facts data.
```
query1 = {"source": "covidcast",
          "data_source": "usa-facts",
          "signal": "deaths_incidence_num",
          "time_type": "day",
          "geo_type": "county",
          "time_values": "20200301-2020501",
          "geo_value": "*"}
measure_database([("usa-facts", "202003*_county*"), ("usa-facts", "202004*_county*")],
                 client,
                 container,
                 [query1],
                 append_data=True)
```
Output. Note the user will have to remember the append_data=True since the output doesn't note that. I guess I could just add a key for that..:
```
{
  "load": [<metrics>, <metrics>],
  "meta": [<metrics>, <metrics>],
  "query1": [<metrics>, <metrics>]
}
```

