### PR TITLE
[Database metrics] Change endpoint for query 

### DIFF
--- a/src/database_metrics/actions.py
+++ b/src/database_metrics/actions.py
@@ -19,7 +19,7 @@ def send_query(params: dict) -> Response:
     -------
     Requests Response object.
     """
-    req = requests.get("http://localhost:10080/epidata/api.php",
+    req = requests.get("http://delphi_web_epidata:10080/epidata/api.php",
                        params=params)
     return req
 


### PR DESCRIPTION
Since this code will run on the python docker, the endpoint needs to be the epidata server container name instead of localhost in order for the python docker to connect.