### PR TITLE
[Database metrics] Add argument for Docker image

### DIFF
--- a/src/database_metrics/README.md
+++ b/src/database_metrics/README.md
@@ -44,7 +44,7 @@ docstring for more information. Example:
     monitor.measure_database(datasets,
                              client,
                              "delphi_database_epidata",
-                             "delphi-python"
+                             "delphi_python",
                              queries,
-                             append_data=True)
+                             append_datasets=True)
     ```

--- a/src/database_metrics/README.md
+++ b/src/database_metrics/README.md
@@ -38,7 +38,7 @@ docstring for more information. Example:
                "time_type": "day",
                "geo_type": "*",
                "time_values": "20200301-2020801",
-               "geo_value": "*"}
+               "geo_value": "*"}]
     datasets = [("usa-facts", "202003*_county*"), 
                 ("usa-facts", "202004*_county*")]
     monitor.measure_database(datasets,

--- a/src/database_metrics/README.md
+++ b/src/database_metrics/README.md
@@ -14,4 +14,37 @@ sub folders corresponding to the production ingestion structure: `common_full/co
     a. Build the `delphi_web`, `delphi_web_epidata`, `delphi_database`, and `delphi_python` images. 
     b. Create the `delphi-net` network.  
     c. Run the database and web server.  
-5. TODO #35. TBD based on exact user-facing implementation
+5. Run the Python docker container, with the host docker.sock mounted,
+in interactive mode, which should bring up a Python shell.: 
+`docker run --rm -it --network delphi-net -v /var/run/docker.sock:/var/run/docker.sock delphi_python`
+6. Import the `database_metrics.monitor` module: `from delphi.operations.database_metrics import monitor`
+7. Run `monitor.measure_database` on your desired datasets and queries. See the function 
+docstring for more information. Example: 
+    ```
+    import docker
+    from delphi.operations.database_metrics import monitor
+    
+    client = docker.from_env()
+    queries = [{"source": "covidcast",
+               "data_source": "usa-facts",
+               "signal": "deaths_incidence_num",
+               "time_type": "day",
+               "geo_type": "county",
+               "time_values": "20200301-2020501",
+               "geo_value": "*"},
+               {"source": "covidcast",
+               "data_source": "usa-facts",
+               "signal": "confirmed_incidence_num",
+               "time_type": "day",
+               "geo_type": "*",
+               "time_values": "20200301-2020801",
+               "geo_value": "*"}
+    datasets = [("usa-facts", "202003*_county*"), 
+                ("usa-facts", "202004*_county*")]
+    monitor.measure_database(datasets,
+                             client,
+                             "delphi_database_epidata",
+                             "delphi-python"
+                             queries,
+                             append_data=True)
+    ```

--- a/src/database_metrics/actions.py
+++ b/src/database_metrics/actions.py
@@ -24,7 +24,10 @@ def send_query(params: dict) -> Response:
     return req
 
 
-def load_data(client: DockerClient, source: str, file_pattern: str) -> bytes:
+def load_data(client: DockerClient,
+              image: str,
+              source: str,
+              file_pattern: str) -> bytes:
     """
     Ingest data into epidata database using the Python docker image.
 
@@ -36,6 +39,8 @@ def load_data(client: DockerClient, source: str, file_pattern: str) -> bytes:
     ----------
     client: DockerClient
         Docker Client object containing the Python image.
+    image: str
+        Name of image containing data loading code.
     source: str
         Data source name
     file_pattern: str
@@ -46,7 +51,7 @@ def load_data(client: DockerClient, source: str, file_pattern: str) -> bytes:
     Bytestring of Docker log, either STDOUT or STDERR
     """
     return client.containers.run(
-        image=client.images.get("delphi_python"),
+        image=client.images.get(image),
         command=f'bash -c "mkdir -p /common/covidcast/receiving/{source} && '
                 f'cp common_full/covidcast/receiving/{source}/{file_pattern} '
                 f'/common/covidcast/receiving/{source}/ && '
@@ -55,7 +60,8 @@ def load_data(client: DockerClient, source: str, file_pattern: str) -> bytes:
         network="delphi-net")
 
 
-def update_meta(client: DockerClient) -> bytes:
+def update_meta(client: DockerClient,
+                image: str) -> bytes:
     """
     Update metadata cache in database.
 
@@ -63,12 +69,14 @@ def update_meta(client: DockerClient) -> bytes:
     ----------
     client: DockerClient
         Docker Client object containing the Python image.
+    image: str
+        Name of image containing metadata update code.
 
     Returns
     -------
     Bytestring of Docker log, either STDOUT or STDERR
     """
     return client.containers.run(
-        image=client.images.get("delphi_python"),
+        image=client.images.get(image),
         command="python3 -m delphi.epidata.acquisition.covidcast.covidcast_meta_cache_updater",
         network="delphi-net")

--- a/src/database_metrics/actions.py
+++ b/src/database_metrics/actions.py
@@ -19,7 +19,7 @@ def send_query(params: dict) -> Response:
     -------
     Requests Response object.
     """
-    req = requests.get("http://delphi_web_epidata:10080/epidata/api.php",
+    req = requests.get("http://delphi_web_epidata:80/epidata/api.php",
                        params=params)
     return req
 

--- a/src/database_metrics/monitor.py
+++ b/src/database_metrics/monitor.py
@@ -58,7 +58,7 @@ def measure_database(datasets: list,
         output["load"].append(parse_metrics(get_metrics(load_func, db)))
         output["meta"].append(parse_metrics(get_metrics(meta_func, db)))
         for i, query in enumerate(query_funcs):
-            output[f"query{i}"] = output.get(f"query{i}", []) + [parse_metrics(get_metrics(query, db_container))]
+            output[f"query{i}"] = output.get(f"query{i}", []) + [parse_metrics(get_metrics(query, db))]
     return output
 
 

--- a/src/database_metrics/monitor.py
+++ b/src/database_metrics/monitor.py
@@ -7,7 +7,7 @@ from docker.models.containers import Container
 from docker import DockerClient
 from delphi.operations.database_metrics.db_actions import _get_epidata_db_size, \
     _get_covidcast_rows, \
-    _clear_db,
+    _clear_db, \
     _clear_cache
 from delphi.operations.database_metrics.actions import load_data, update_meta, send_query
 from delphi.operations.database_metrics.parsers import parse_metrics
@@ -53,8 +53,8 @@ def measure_database(datasets: list,
     of parse_metrics() for loading, metadata updates, and queries.
     """
     db = client.containers.get(db_container)
-    output = {"load": [], "meta": [], "datasets": datasets,
-              "append_datasets": append_datasets, "queries": queries}
+    output = {"load": [], "meta": [], "datasets": datasets, "queries": queries,
+              "append_datasets": append_datasets}
     query_funcs = [partial(send_query, params=p) for p in queries] if queries is not None else []
     meta_func = partial(update_meta, client=client, image=image)
     for dataset in datasets:
@@ -67,7 +67,7 @@ def measure_database(datasets: list,
         for i, query in enumerate(query_funcs):
             output[f"query{i}"] = output.get(f"query{i}", [])
             output[f"query{i}"].append(parse_metrics(get_metrics(query, db_container, clear_cache)))
-        return output
+    return output
 
 
 def get_metrics(func: Callable, container: Container, clear_cache: bool) -> tuple:

--- a/src/database_metrics/monitor.py
+++ b/src/database_metrics/monitor.py
@@ -14,7 +14,7 @@ from delphi.operations.database_metrics.parsers import parse_metrics
 
 def measure_database(datasets: list,
                      client: DockerClient,
-                     db_container: Container,
+                     db_container: str = "delphi_database_epidata",
                      image: str = "delphi-python",
                      queries: list = None,
                      append_datasets: bool = False) -> dict:
@@ -32,10 +32,10 @@ def measure_database(datasets: list,
         List of 2-tuples defined as (source, patterns for files) to be included in each dataset.
     client: DockerClient
         DockerClient object to access and execute python images.
-    db_container: str
+    db_container: str, optional
         Name of Docker container containing the database to measure.
     image: str, optional
-        Name of Docker image containing the data loading and metadata updating code. Defaults to 'delphi-python'.
+        Name of Docker image containing the data loading and metadata updating code.
     queries: list of dictionaries, optional
         List of query parameters to test query runtimes on. Defaults to empty list.
     append_datasets: boolean, optional

--- a/tests/database_metrics/test_monitor.py
+++ b/tests/database_metrics/test_monitor.py
@@ -14,11 +14,8 @@ class TestMonitor(unittest.TestCase):
     @patch("delphi.operations.database_metrics.monitor.parse_metrics")
     @patch("delphi.operations.database_metrics.monitor.get_metrics")
     def test_measure_database(self, mock_metrics, mock_parser, mock_clear):
-        # mock_container = MagicMock()
-        # mock_container.exec_run.return_value = None
-        # mock_docker_client = MagicMock()
-        # mock_docker_client.containers.run.return_value = mock_container
-
+        mock_client = MagicMock()
+        mock_client.containers.get.return_value = None
         mock_metrics.return_value = None
         mock_clear.return_value = None
         mock_parser.side_effect = [
@@ -29,9 +26,12 @@ class TestMonitor(unittest.TestCase):
             {"table_rows": 1, "db_disk_usage_mb": 3., "runtime": 5, "memory_usage_mb": 7},
             {"table_rows": 3, "db_disk_usage_mb": 6., "runtime": 9, "memory_usage_mb": 12},
         ]
+        test_datasets = [("a", "b"), ("c", "d")]
+        test_queries = ["q0"]
         expected = {
-            "datasets": [("a", "b"), ("c", "d")],
+            "datasets": test_datasets,
             "append_datasets": False,
+            "queries": test_queries,
             "load": [
                 {"table_rows": 1, "db_disk_usage_mb": 2., "runtime": 3, "memory_usage_mb": 4},
                 {"table_rows": 2, "db_disk_usage_mb": 4., "runtime": 6, "memory_usage_mb": 8}
@@ -45,6 +45,6 @@ class TestMonitor(unittest.TestCase):
                 {"table_rows": 3, "db_disk_usage_mb": 6., "runtime": 9, "memory_usage_mb": 12}
             ],
         }
-        output = monitor.measure_database([("a", "b"), ("c", "d")], None, None, ["q1"])
+        output = monitor.measure_database(test_datasets, mock_client, "container", "image", test_queries)
         self.assertDictEqual(output, expected)
         self.assertEqual(mock_clear.call_count, 2)


### PR DESCRIPTION
Add an argument for which image to use to load/meta update in case you want to compare two different images. It's a bit clunky because this code runs inside the container that holds that code (delphi-python), but I imagine the workflow is probably something like 
1. run the existing code using the readme instructions, so you'll have a image delphi-python with the load/meta update code as well as the metrics code
2. checkout revision branch and build new image with new name, e.g. delphi-python2 
3. run the metrics code on delphi-python and tell it to use the delphi-python2 image as the load/update image.

Summary of changes
- Add an image argument to relevant functions
- Update readme with usage example
- Update measure_database to take in a string to specify container instead of the container itself, just so it's consistent with the image arg (also add default arg).
- Update test for new interface with increasingly many mocks
- _Unrelated_ add query input list input output dictionary so it's still there for reference
- _Unrelated 1 line bug fix change:_ Update port number for query requests to be the original one, not the exposed one. 