### PR TITLE
[Database metrics] Add start/end metrics for size and rows

### DIFF
--- a/src/database_metrics/monitor.py
+++ b/src/database_metrics/monitor.py
@@ -9,7 +9,7 @@ from delphi.operations.database_metrics.db_actions import _get_epidata_db_size, 
     _get_covidcast_rows, \
     _clear_db
 from delphi.operations.database_metrics.actions import load_data, update_meta, send_query
-from delphi.operations.database_metrics.parsers import parse_metrics
+from delphi.operations.database_metrics.parsers import parse_metrics, parse_row_count, parse_db_size
 
 
 def measure_database(datasets: list,
@@ -81,10 +81,12 @@ def get_metrics(func: Callable, container: Container) -> tuple:
 
     Returns
     -------
-    3-Tuple of final disk usage, runtime, and list of dicts containing docker stats.
+    6-Tuple of start/end disk usage, start/end covidcast table size, runtime, and list of dicts containing docker stats.
     """
     worker_process = mp.Process(target=func)
     container_stats = [container.stats(stream=False)]  # get one stat right before starting process
+    start_size = _get_epidata_db_size(container).output
+    start_rows = _get_covidcast_rows(container).output
     start_time = time.time()
     worker_process.start()
     for stat in container.stats(decode=True):
@@ -93,7 +95,11 @@ def get_metrics(func: Callable, container: Container) -> tuple:
         else:
             break
     end_time = time.time()
-    return (_get_covidcast_rows(container).output,
-            _get_epidata_db_size(container).output,
+    end_size = _get_epidata_db_size(container).output
+    end_rows = _get_covidcast_rows(container).output
+    return (parse_db_size(start_size),
+            parse_db_size(end_size),
+            parse_row_count(start_rows),
+            parse_row_count(end_rows),
             end_time-start_time,
             container_stats)

--- a/src/database_metrics/parsers.py
+++ b/src/database_metrics/parsers.py
@@ -54,14 +54,18 @@ def parse_metrics(metrics: tuple) -> dict:
     Parameters
     ----------
     metrics: tuple
-        3-Tuple of metrics output by get_metrics().
+        Tuple of metrics output by get_metrics().
 
     Returns
     -------
-    Dictionary containing the number of rows in the database, final disk usage, runtime, and the maximum memory usage queried during the function call.
+    Dictionary containing the final rows in the covidcast table, rows loaded to the the covidcast table during the
+    operation, final database size, change in database size during the operation, runtime, and the maximum memory
+    usage queried during the function call.
     """
-    output = {"table_rows": parse_row_count(metrics[0]),
-              "db_disk_usage_mb": parse_db_size(metrics[1]),
-              "runtime": metrics[2],
-              "memory_usage_mb": max(i["memory_stats"]["usage"] / 1024 / 1024 for i in metrics[3])}
+    output = {"final_table_rows": metrics[3],
+              "rows_loaded": metrics[3] - metrics[2],
+              "db_size_mb": metrics[1],
+              "size_loaded_mb": metrics[1] - metrics[0],
+              "runtime": metrics[4],
+              "peak_memory_mb": max(i["memory_stats"]["usage"] / 1024 / 1024 for i in metrics[5])}
     return output

--- a/tests/database_metrics/test_monitor.py
+++ b/tests/database_metrics/test_monitor.py
@@ -18,31 +18,30 @@ class TestMonitor(unittest.TestCase):
         # mock_container.exec_run.return_value = None
         # mock_docker_client = MagicMock()
         # mock_docker_client.containers.run.return_value = mock_container
-
         mock_metrics.return_value = None
         mock_clear.return_value = None
         mock_parser.side_effect = [
-            {"table_rows": 1, "db_disk_usage_mb": 2., "runtime": 3, "memory_usage_mb": 4},
-            {"table_rows": 5, "db_disk_usage_mb": 6., "runtime": 7, "memory_usage_mb": 8},
-            {"table_rows": 9, "db_disk_usage_mb": 10., "runtime": 11, "memory_usage_mb": 12},
-            {"table_rows": 2, "db_disk_usage_mb": 4., "runtime": 6, "memory_usage_mb": 8},
-            {"table_rows": 1, "db_disk_usage_mb": 3., "runtime": 5, "memory_usage_mb": 7},
-            {"table_rows": 3, "db_disk_usage_mb": 6., "runtime": 9, "memory_usage_mb": 12},
+            {"a": 1, "b": 2., "c": 3, "d": 4},
+            {"a": 5, "b": 6., "c": 7, "d": 8},
+            {"a": 9, "b": 10., "c": 11, "d": 12},
+            {"a": 2, "b": 4., "c": 6, "d": 8},
+            {"a": 1, "b": 3., "c": 5, "d": 7},
+            {"a": 3, "b": 6., "c": 9, "d": 12},
         ]
         expected = {
             "datasets": [("a", "b"), ("c", "d")],
             "append_datasets": False,
             "load": [
-                {"table_rows": 1, "db_disk_usage_mb": 2., "runtime": 3, "memory_usage_mb": 4},
-                {"table_rows": 2, "db_disk_usage_mb": 4., "runtime": 6, "memory_usage_mb": 8}
+                {"a": 1, "b": 2., "c": 3, "d": 4},
+                {"a": 2, "b": 4., "c": 6, "d": 8}
             ],
             "meta": [
-                {"table_rows": 5, "db_disk_usage_mb": 6., "runtime": 7, "memory_usage_mb": 8},
-                {"table_rows": 1, "db_disk_usage_mb": 3., "runtime": 5, "memory_usage_mb": 7}
+                {"a": 5, "b": 6., "c": 7, "d": 8},
+                {"a": 1, "b": 3., "c": 5, "d": 7}
             ],
             "query0": [
-                {"table_rows": 9, "db_disk_usage_mb": 10., "runtime": 11, "memory_usage_mb": 12},
-                {"table_rows": 3, "db_disk_usage_mb": 6., "runtime": 9, "memory_usage_mb": 12}
+                {"a": 9, "b": 10., "c": 11, "d": 12},
+                {"a": 3, "b": 6., "c": 9, "d": 12}
             ],
         }
         output = monitor.measure_database([("a", "b"), ("c", "d")], None, None, ["q1"])

--- a/tests/database_metrics/test_monitor.py
+++ b/tests/database_metrics/test_monitor.py
@@ -21,27 +21,27 @@ class TestMonitor(unittest.TestCase):
         mock_metrics.return_value = None
         mock_clear.return_value = None
         mock_parser.side_effect = [
-            {"a": 1, "b": 2., "c": 3, "d": 4},
-            {"a": 5, "b": 6., "c": 7, "d": 8},
-            {"a": 9, "b": 10., "c": 11, "d": 12},
-            {"a": 2, "b": 4., "c": 6, "d": 8},
-            {"a": 1, "b": 3., "c": 5, "d": 7},
-            {"a": 3, "b": 6., "c": 9, "d": 12},
+            {"test": "output1"},
+            {"test": "output2"},
+            {"test": "output3"},
+            {"test": "output4"},
+            {"test": "output5"},
+            {"test": "output6"}
         ]
         expected = {
             "datasets": [("a", "b"), ("c", "d")],
             "append_datasets": False,
             "load": [
-                {"a": 1, "b": 2., "c": 3, "d": 4},
-                {"a": 2, "b": 4., "c": 6, "d": 8}
+                {"test": "output1"},
+                {"test": "output4"},
             ],
             "meta": [
-                {"a": 5, "b": 6., "c": 7, "d": 8},
-                {"a": 1, "b": 3., "c": 5, "d": 7}
+                {"test": "output2"},
+                {"test": "output5"},
             ],
             "query0": [
-                {"a": 9, "b": 10., "c": 11, "d": 12},
-                {"a": 3, "b": 6., "c": 9, "d": 12}
+                {"test": "output3"},
+                {"test": "output6"},
             ],
         }
         output = monitor.measure_database([("a", "b"), ("c", "d")], None, None, ["q1"])

--- a/tests/database_metrics/test_parsers.py
+++ b/tests/database_metrics/test_parsers.py
@@ -16,14 +16,18 @@ class TestParser(unittest.TestCase):
         self.assertEqual(parse_row_count(test_query_result), 1604)
 
     def test_metrics(self):
-        test_metrics = (b'count(*)\n1604\n',
-                        b'db\tsize_mb\nepidata\t7.79687500\ninformation_schema\t0.18750000\n',
+        test_metrics = (100.5,
+                        120,
+                        10,
+                        25,
                         1,
                         [{"memory_stats": {"usage": 3}}, {"memory_stats": {"usage": 4}}])
         self.assertDictEqual(
             parse_metrics(test_metrics),
-            {"table_rows": 1604,
-             "db_disk_usage_mb": 7.796875,
+            {"final_table_rows": 25,
+             "rows_loaded": 15,
+             "db_size_mb": 120,
+             "size_loaded_mb": 19.5,
              "runtime": 1,
-             "memory_usage_mb": 4/1024/1024}
+             "peak_memory_mb": 4/1024/1024}
         )


### PR DESCRIPTION
Realized some more metrics would be useful
Summary of changes:
- Capture the start and end covidcast table size and epidata database size, and have the parsers calculate the total rows/MB loaded.
