### PR TITLE
fix prod detection

### DIFF
--- a/src/environment.py
+++ b/src/environment.py
@@ -9,4 +9,4 @@ class Environment:
   @staticmethod
   def is_prod():
     """Return whether this is running in production."""
-    return socket.gethostname() == 'delphi.midas.cs.cmu.edu'
+    return socket.gethostname() == 'delphi-master-prod-01.delphi.cmu.edu'


### PR DESCRIPTION
some tests fail because the prod environment is incorrectly detected as a dev environment. this updates the hostname so that the environment is correctly recognized.

note that `delphi-master-prod-01.delphi.cmu.edu` is the CNAME for `delphi.midas.cs.cmu.edu`

```
# dig -t a delphi-master-prod-01.delphi.cmu.edu

;; ANSWER SECTION:
delphi-master-prod-01.delphi.cmu.edu. 899 IN A	128.2.25.177

# dig -t a delphi.midas.cs.cmu.edu

;; ANSWER SECTION:
delphi.midas.cs.cmu.edu. 299	IN	CNAME	delphi-master-prod-01.delphi.cmu.edu.
delphi-master-prod-01.delphi.cmu.edu. 899 IN A	128.2.25.177
```