### PR TITLE
Add delphi_utils to python Docker requirements

### DIFF
--- a/dev/docker/python/assets/requirements.txt
+++ b/dev/docker/python/assets/requirements.txt
@@ -1,6 +1,7 @@
 aiohttp
 beautifulsoup4
 covidcast
+delphi_utils
 docker
 dropbox
 epiweeks


### PR DESCRIPTION
Required for the [nans acquisition code](https://github.com/cmu-delphi/delphi-epidata/pull/417) to run in Docker.