### PR TITLE
Update front-end dev docs

### DIFF
--- a/docs/frontend_development.md
+++ b/docs/frontend_development.md
@@ -98,6 +98,10 @@ Note that these images aren't very useful at this point. Each frontend will
 extend and customize these images as necessary to replicate the server's
 environment for that frontend.
 
+To work with the new Python server, you will need the new image specified
+[here](https://github.com/cmu-delphi/delphi-epidata/blob/76cc4c513fe1fa64eede08a6a9202aaa25e0dc1b/dev/docker/python/Dockerfile). See the [CI recipe](https://github.com/cmu-delphi/delphi-epidata/blob/76cc4c513fe1fa64eede08a6a9202aaa25e0dc1b/.github/workflows/ci.yaml#L54) for the latest instructions
+on how to build, test, and run locally.
+
 # test
 
 After the images specific to your frontend have been built, you're ready to

--- a/docs/frontend_development.md
+++ b/docs/frontend_development.md
@@ -98,8 +98,11 @@ Note that these images aren't very useful at this point. Each frontend will
 extend and customize these images as necessary to replicate the server's
 environment for that frontend.
 
-To work with the new Python server, you will need the new image specified
-[here](https://github.com/cmu-delphi/delphi-epidata/blob/76cc4c513fe1fa64eede08a6a9202aaa25e0dc1b/dev/docker/python/Dockerfile). See the [CI recipe](https://github.com/cmu-delphi/delphi-epidata/blob/76cc4c513fe1fa64eede08a6a9202aaa25e0dc1b/.github/workflows/ci.yaml#L54) for the latest instructions
+To work with the new Python server, you will need the new Python image specified
+[here](https://github.com/cmu-delphi/delphi-epidata/blob/76cc4c513fe1fa64eede08a6a9202aaa25e0dc1b/dev/docker/python/Dockerfile)
+and replace the `delph_epidata_web` image with the image here
+[here](https://github.com/cmu-delphi/delphi-epidata/blob/76cc4c513fe1fa64eede08a6a9202aaa25e0dc1b/devops/Dockerfile).
+See the [CI recipe](https://github.com/cmu-delphi/delphi-epidata/blob/76cc4c513fe1fa64eede08a6a9202aaa25e0dc1b/.github/workflows/ci.yaml#L54) for the latest instructions
 on how to build, test, and run locally.
 
 # test

--- a/docs/frontend_development.md
+++ b/docs/frontend_development.md
@@ -98,10 +98,12 @@ Note that these images aren't very useful at this point. Each frontend will
 extend and customize these images as necessary to replicate the server's
 environment for that frontend.
 
-To work with the new Python server, you will need the new Python image specified
-[here](https://github.com/cmu-delphi/delphi-epidata/blob/76cc4c513fe1fa64eede08a6a9202aaa25e0dc1b/dev/docker/python/Dockerfile)
-and replace the `delph_epidata_web` image with the image here
-[here](https://github.com/cmu-delphi/delphi-epidata/blob/76cc4c513fe1fa64eede08a6a9202aaa25e0dc1b/devops/Dockerfile).
+The below was written before we switched the delphi-epidata API server to Python/Flask. 
+If you are following this guide in order to develop on delphi-epidata, you should build 
+[this Python image](https://github.com/cmu-delphi/delphi-epidata/blob/76cc4c513fe1fa64eede08a6a9202aaa25e0dc1b/dev/docker/python/Dockerfile)
+as `delphi_web_python` and use it in place of `delphi_python`, and use 
+[this web image](https://github.com/cmu-delphi/delphi-epidata/blob/76cc4c513fe1fa64eede08a6a9202aaa25e0dc1b/devops/Dockerfile)
+for `delphi_epidata_web`.
 See the [CI recipe](https://github.com/cmu-delphi/delphi-epidata/blob/76cc4c513fe1fa64eede08a6a9202aaa25e0dc1b/.github/workflows/ci.yaml#L54) for the latest instructions
 on how to build, test, and run locally.
 


### PR DESCRIPTION
A minimal pointer to the delphi-epidata CI, which contains up-to-date recipes for building the Docker containers. [Ref](https://github.com/cmu-delphi/delphi-epidata/pull/417).

May be worth rewriting a larger chunk of this in the future.