### PR TITLE
Remove unused undefx depends from installation script

### DIFF
--- a/dev/docker/python/assets/setup.sh
+++ b/dev/docker/python/assets/setup.sh
@@ -12,11 +12,6 @@
 # bail if anything fails
 set -e
 
-# create python package `undefx`
-mkdir undefx
-mv repos/undefx/py3tester/src undefx/py3tester
-mv repos/undefx/undef-analysis undefx/undef_analysis
-
 # create python package `delphi`
 mkdir delphi
 mv repos/delphi/operations/src delphi/operations


### PR DESCRIPTION
This script is used [here](https://github.com/cmu-delphi/operations/blob/66309d158de862de2b61d9696d11e05d617c1229/dev/docker/python/Dockerfile#L19), which builds one of our basic python images. By removing this, developers no longer need to git clone `undefx/py3tester` or `undefx/undef_analysis`.

Before doing this, we probably should discuss and converge on:
- [ ]  which dependencies are need and which can be removed; the answer here will be different for each repo in `cmu-delphi`; cmu-delphi/delphi-epidata#965 has a list of org repos that depend on the Dockerfiles here
- [ ] whether we can separate the installation script here from what's needed in `delphi-epidata`